### PR TITLE
docs: add devsquad smoke test v2 documentation

### DIFF
--- a/docs/devsquad-smoke-v2.md
+++ b/docs/devsquad-smoke-v2.md
@@ -1,0 +1,1 @@
+# Dev Squad smoke test v2


### PR DESCRIPTION
# Dev Squad smoke test v2

Add a file at docs/devsquad-smoke-v2.md containing the line: '# Dev Squad smoke test v2'. Only this single file.