### PR TITLE
feat(dev-15): Codex CLI session type

### DIFF
--- a/docs/dev-squad/dev-15-codex-cli-session-type.md
+++ b/docs/dev-squad/dev-15-codex-cli-session-type.md
@@ -1,0 +1,134 @@
+# DEV-15: Codex CLI Session Type
+
+> Issue: DEV-15
+> Mode: refine
+
+## Summary
+
+Add `'codex'` as a first-class `SessionType` in Deck so that users can create Codex CLI sessions
+with the same creation flow and affordances as `claude-code` sessions. The session header badge
+renders "codex" in cyan, the configurable CLI path defaults to `codex`, and a missing binary
+surfaces naturally through the PTY terminal output rather than hanging silently.
+
+## User Stories
+
+- **US-1** As a developer, I want to create a Codex CLI session in Deck, so that I can run the
+  Codex CLI alongside Claude Code sessions without switching apps.
+  - Acceptance: The session creation dialog (SessionDialog / GlobalSessionDialog) lists "codex"
+    as a selectable type. Choosing it creates a session with `type = 'codex'` and the configured
+    codex command running in the PTY.
+- **US-2** As a developer, I want the session header to show a distinct "codex" badge, so that
+  I can tell session types apart at a glance.
+  - Acceptance: `SessionHeader.getConfigLabel()` returns `{ label: 'codex', variant: 'cyan' }`
+    for `session.type === 'codex'`; the badge renders in cyan (variant already supported by
+    `ConfigBadge`).
+- **US-3** As a developer, I want to configure the codex CLI path in Settings, so that I can
+  point Deck at a non-default installation.
+  - Acceptance: `SettingsDialog` exposes a "Codex path" text field bound to
+    `DeckSettings.codexPath`. Leaving it blank defaults to `'codex'`. Value is persisted and
+    used as the default command when creating a codex session without an explicit command.
+- **US-4** As a developer, if the codex binary is absent, I want a visible error in the terminal
+  rather than a silent hang, so that I know what went wrong.
+  - Acceptance: Running a codex session with an invalid binary path shows the shell's
+    "command not found" output in the PTY terminal and the session remains idle. No special
+    UI crash or hang occurs. (Existing PTY behavior already provides this.)
+
+## Functional Requirements
+
+- **FR-001** The `SessionType` union in `src/shared/ipc.ts` MUST include the literal `'codex'`.
+- **FR-002** `SessionManager.create()` MUST recognize `req.type === 'codex'` and persist
+  `type = 'codex'` in the sessions table — parallel to how `'shell'` and `'ssh'` are handled.
+- **FR-003** `SessionManager.rowToSession()` MUST map `row.type === 'codex'` to `'codex'`
+  before the existing `'claude-code'` fallback so restored sessions keep their type.
+- **FR-004** When `type === 'codex'` and `req.command` is not provided, `SessionManager.create()`
+  MUST use `settings.codexPath ?? 'codex'` as the session command.
+- **FR-005** `DeckSettings` MUST include `codexPath?: string` (optional; default resolved at
+  runtime to `'codex'` when absent or empty).
+- **FR-006** `SettingsDialog` MUST expose a "Codex path" text input bound to
+  `DeckSettings.codexPath`; saving persists the value via `DeckSettingsApi.set()`.
+- **FR-007** `SessionHeader.getConfigLabel()` MUST return `{ label: 'codex', variant: 'cyan' }`
+  for `session.type === 'codex'`.
+- **FR-008** The session creation UI (`SessionDialog.tsx`, `GlobalSessionDialog.tsx`) MUST list
+  `'codex'` as a selectable type alongside `'claude-code'`, `'shell'`, and `'ssh'`.
+- **FR-009** Codex sessions MUST only support `kind = 'executor'`. The creation form MUST hide
+  or disable the planner option when `'codex'` is selected (codex has no planner mode).
+
+## Non-Functional / Constraints
+
+- **Locked files** (from CLAUDE.md — developer must review these changes carefully):
+  `src/main/session-manager.ts` (core session logic, planner attachment rules),
+  `src/main/db/migrations.ts` (append-only, never edit existing entries)
+- **Stack constraints**: TypeScript 5.9 strict, no `any`, named exports only, single quotes,
+  no semicolons, `printWidth: 100`, `trailingComma: 'none'`
+- **ESLint**: never scatter `// eslint-disable-next-line` — refactor or change rule globally
+- **DB**: `type` column is plain TEXT with no CHECK constraint (confirmed in `schema.sql`),
+  so no migration is needed to store `'codex'`. Migrations are append-only; do not edit v1–v5.
+- **xterm.js**: do not remount the terminal during type selection in the creation dialog
+- **macOS only**: no Windows path separator handling needed
+
+## Out of Scope
+
+- Codex planner sessions (no planner concept in the Codex CLI).
+- Codex session resume / `--session-id` equivalent (not defined for Phase 2).
+- SSH tunnelling for codex sessions.
+- Codex-specific tool allow/disallow lists.
+- Windows or Linux binary path handling.
+- Auto-detection of the codex binary location at startup.
+
+## Files Affected
+
+### Modify
+- `src/shared/ipc.ts` — add `'codex'` to `SessionType` union (line 5); add `codexPath?: string`
+  to `DeckSettings` interface (around line 270)
+- `src/main/session-manager.ts` — update `rowToSession()` type coercion to handle `'codex'`;
+  update `create()` type coercion and command defaulting to use `settings.codexPath ?? 'codex'`
+  when `type === 'codex'` and no explicit command is supplied
+- `src/renderer/src/components/session/SessionHeader.tsx` — add `codex` branch in
+  `getConfigLabel()` returning `{ label: 'codex', variant: 'cyan' }`
+- `src/renderer/src/components/settings/SettingsDialog.tsx` — add "Codex path" text input
+  bound to `DeckSettings.codexPath`
+- `src/renderer/src/components/sidebar/SessionDialog.tsx` — add `'codex'` as a type option;
+  hide planner kind selector when codex is selected
+- `src/renderer/src/components/GlobalSessionDialog.tsx` — same type option and planner-hiding
+  as `SessionDialog.tsx`
+
+### Create
+_(none)_
+
+### Delete
+_(none)_
+
+## Test Plan
+
+### Automated (Developer + QA run literally)
+- `pnpm typecheck` → exit 0
+- `pnpm lint` → exit 0, no new warnings
+- `pnpm test --run` → all pass
+- `pnpm db:smoke` → migrations pass (no new migration added, but verify existing pass)
+- `pnpm session:smoke` → session manager tests pass
+
+### Manual (QA executes step-by-step)
+1. Open Deck → click "New Session" → verify the type selector lists "Codex" alongside
+   Claude Code, Shell, SSH → expected: all four options visible.
+2. Select type "Codex" → verify the planner kind option is hidden/disabled →
+   expected: only "Executor" kind available.
+3. Create a Codex session with default settings → expected: session created, terminal opens,
+   badge in `SessionHeader` is cyan and labelled "codex".
+4. Open Settings → verify a "Codex path" field exists → enter `/usr/local/bin/codex` →
+   save → create a new Codex session with no explicit command → expected: PTY runs the
+   command at the configured path.
+5. Set "Codex path" to `/nonexistent/codex` → create a Codex session → expected: terminal
+   shows `zsh: command not found: /nonexistent/codex` (or equivalent); session stays idle,
+   no app crash or hang.
+6. Restart Deck after creating a codex session → reopen the session → expected: badge still
+   shows cyan "codex", type is preserved from SQLite.
+
+## Open Questions
+
+- **Q1** `SessionDialog.tsx` and `GlobalSessionDialog.tsx` may share a type-picker component
+  or duplicate logic — confirm before implementing so the codex option is added once.
+  Recommendation: grep for the type selector UI and extract a shared component if needed.
+- **Q2** Does the creation form currently pre-fill `command` from `settings.defaultExecutorCommand`
+  for `claude-code` sessions? If yes, follow the same pattern for codex using `codexPath`.
+  Recommendation: read `SessionDialog.tsx` top-to-bottom before writing the codex command
+  defaulting logic.

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -158,7 +158,9 @@ export class SessionManager extends EventEmitter<EventMap> {
         ? 'ssh'
         : row.type === 'shell'
           ? 'shell'
-          : 'claude-code') as SessionType,
+          : row.type === 'codex'
+            ? 'codex'
+            : 'claude-code') as SessionType,
       claudeSessionId: row.claude_session_id ?? null,
       parentSessionId: row.parent_session_id ?? null,
       createdAt: row.created_at,
@@ -189,7 +191,13 @@ export class SessionManager extends EventEmitter<EventMap> {
     const name = validateNonEmpty('name', req.name)
     const cwd = validateNonEmpty('cwd', req.cwd)
     const type: SessionType =
-      req.type === 'ssh' ? 'ssh' : req.type === 'shell' ? 'shell' : 'claude-code'
+      req.type === 'ssh'
+        ? 'ssh'
+        : req.type === 'shell'
+          ? 'shell'
+          : req.type === 'codex'
+            ? 'codex'
+            : 'claude-code'
     const subText = req.subText ?? ''
     const kind = req.kind ?? 'executor'
 
@@ -226,8 +234,18 @@ export class SessionManager extends EventEmitter<EventMap> {
       if (config.allowedTools) parts.push(`--allowedTools`, config.allowedTools)
       parts.push(`--append-system-prompt`, shellQuote(promptNormalized))
       command = parts.join(' ')
+    } else if (type === 'shell') {
+      command = req.command ?? ''
+    } else if (type === 'codex') {
+      const explicit = (req.command ?? '').trim()
+      if (explicit.length > 0) {
+        command = explicit
+      } else {
+        const codexPath = (this.getSettings().codexPath ?? '').trim()
+        command = codexPath.length > 0 ? codexPath : 'codex'
+      }
     } else {
-      command = type === 'shell' ? (req.command ?? '') : validateNonEmpty('command', req.command)
+      command = validateNonEmpty('command', req.command)
     }
 
     const id = randomUUID()

--- a/src/renderer/src/components/session/SessionHeader.tsx
+++ b/src/renderer/src/components/session/SessionHeader.tsx
@@ -8,6 +8,7 @@ import type { SessionType } from '../../../../shared/ipc'
 function getConfigLabel(sessionType: SessionType): { label: string; variant: ConfigBadgeVariant } {
   if (sessionType === 'shell') return { label: 'shell', variant: 'neutral' }
   if (sessionType === 'ssh') return { label: 'ssh', variant: 'neutral' }
+  if (sessionType === 'codex') return { label: 'codex', variant: 'cyan' }
   return { label: 'claude-code', variant: 'neutral' }
 }
 

--- a/src/renderer/src/components/settings/SettingsDialog.tsx
+++ b/src/renderer/src/components/settings/SettingsDialog.tsx
@@ -23,6 +23,7 @@ export function SettingsDialog({ onSaved, onClose }: SettingsDialogProps): React
 
   const [customCommand, setCustomCommand] = useState('')
   const [executorCommand, setExecutorCommand] = useState('claude')
+  const [codexPath, setCodexPath] = useState('')
   const [ready, setReady] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -32,6 +33,7 @@ export function SettingsDialog({ onSaved, onClose }: SettingsDialogProps): React
       const s = await window.deck.settings.get()
       setCustomCommand(s.customEditorCommand ?? '')
       setExecutorCommand(s.defaultExecutorCommand)
+      setCodexPath(s.codexPath ?? '')
       setReady(true)
     }
     void loadSettings()
@@ -41,6 +43,8 @@ export function SettingsDialog({ onSaved, onClose }: SettingsDialogProps): React
     if (customCommand.trim() && METACHAR.test(customCommand))
       return 'Command contains invalid characters (; & | $ > < ` \\).'
     if (!executorCommand.trim()) return 'Executor command is required.'
+    if (codexPath.trim() && METACHAR.test(codexPath))
+      return 'Codex path contains invalid characters (; & | $ > < ` \\).'
     return null
   }
 
@@ -55,7 +59,8 @@ export function SettingsDialog({ onSaved, onClose }: SettingsDialogProps): React
     try {
       await window.deck.settings.set({
         customEditorCommand: customCommand.trim() || null,
-        defaultExecutorCommand: executorCommand.trim()
+        defaultExecutorCommand: executorCommand.trim(),
+        codexPath: codexPath.trim()
       })
       await refreshGlobalSettings()
       await onSaved()
@@ -123,6 +128,30 @@ export function SettingsDialog({ onSaved, onClose }: SettingsDialogProps): React
               />
               <p className="font-body text-[11px] text-op-zinc-500">
                 Command used when spawning new executor sessions.
+              </p>
+            </div>
+          </div>
+
+          {/* Codex section */}
+          <div className="flex flex-col gap-3">
+            <p className="font-body text-[11px] font-semibold tracking-[0.08em] uppercase text-op-zinc-500">
+              Codex
+            </p>
+            <div className="flex flex-col gap-1.5">
+              <label className="font-body text-[12px] font-medium text-op-zinc-400">
+                Codex path
+              </label>
+              <input
+                type="text"
+                value={codexPath}
+                onChange={(e) => setCodexPath(e.target.value)}
+                disabled={!ready}
+                placeholder="codex"
+                className="h-9 bg-op-zinc-900 border border-op-zinc-800 rounded-[7px] px-3 text-op-zinc-200 font-mono text-[13px] outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-op-zinc-600 focus:border-accent focus:shadow-[0_0_0_3px_rgba(124,58,237,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <p className="font-body text-[11px] text-op-zinc-500">
+                Binary name or path used when spawning new Codex sessions. Defaults to{' '}
+                <span className="font-mono">codex</span> when blank.
               </p>
             </div>
           </div>

--- a/src/renderer/src/components/sidebar/SessionDialog.tsx
+++ b/src/renderer/src/components/sidebar/SessionDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { FolderOpen, Bot, Terminal, Server, ChevronDown } from 'lucide-react'
+import { FolderOpen, Bot, Terminal, Server, Sparkles, ChevronDown } from 'lucide-react'
 import type { SessionType, SshHost, Workspace } from '../../../../shared/ipc'
 import { useDeckStore } from '@/stores/deck'
 import {
@@ -16,13 +16,15 @@ const LAST_TYPE_KEY = 'deck:lastSessionType'
 
 function getLastType(): SessionType {
   const stored = localStorage.getItem(LAST_TYPE_KEY)
-  if (stored === 'shell' || stored === 'claude-code' || stored === 'ssh') return stored
+  if (stored === 'shell' || stored === 'claude-code' || stored === 'ssh' || stored === 'codex')
+    return stored
   return 'claude-code'
 }
 
 function autoName(workspace: Workspace, type: SessionType, sshAlias?: string): string {
   if (type === 'shell') return `${workspace.name}/shell`
   if (type === 'ssh') return `${workspace.name}/ssh:${sshAlias ?? ''}`
+  if (type === 'codex') return `${workspace.name}/codex`
   return `${workspace.name}/new-session`
 }
 
@@ -119,7 +121,8 @@ export function SessionDialog({
         workspaceId: selectedWorkspace.id,
         name: name.trim(),
         cwd: type === 'ssh' ? selectedWorkspace.path : cwd.trim(),
-        command: type === 'shell' ? '' : type === 'ssh' ? sshAlias : command.trim(),
+        command:
+          type === 'shell' || type === 'codex' ? '' : type === 'ssh' ? sshAlias : command.trim(),
         subText: subText.trim(),
         type
       })
@@ -162,6 +165,11 @@ export function SessionDialog({
                     t: 'claude-code' as SessionType,
                     label: 'Claude Code',
                     icon: <Bot size={14} strokeWidth={1.75} />
+                  },
+                  {
+                    t: 'codex' as SessionType,
+                    label: 'Codex',
+                    icon: <Sparkles size={14} strokeWidth={1.75} />
                   },
                   {
                     t: 'shell' as SessionType,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2,7 +2,7 @@ export type PtyId = string
 export type WorkspaceId = string
 export type SessionId = string
 export type SessionStatus = 'idle' | 'working'
-export type SessionType = 'claude-code' | 'shell' | 'ssh'
+export type SessionType = 'claude-code' | 'shell' | 'ssh' | 'codex'
 export type NotificationState = 'idle' | 'pending' | 'error'
 
 export interface GitInfo {
@@ -273,6 +273,7 @@ export interface DeckSettings {
   plannerPrompt: string | null
   plannerDisallowedTools: string | null
   plannerAllowedTools: string | null
+  codexPath?: string
 }
 
 export interface OpenInEditorRequest {


### PR DESCRIPTION
Implements DEV-15.
Spec: docs/dev-squad/dev-15-codex-cli-session-type.md
FRs: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009 — all green

## Summary
- Add 'codex' as a first-class SessionType parallel to claude-code, shell, ssh.
- Backend: SessionManager persists type='codex', restores it from sqlite, and defaults the command to settings.codexPath ?? 'codex' when no explicit command is supplied.
- Settings: DeckSettings gains optional codexPath; SettingsDialog exposes a 'Codex path' input with the same shell-metachar guard used for the editor command.
- UI: SessionHeader shows a cyan 'codex' badge; SessionDialog/GlobalSessionDialog list 'Codex' as a selectable type with a Sparkles icon. Codex sessions create as executor (no planner attachment).
- Codex submit sends an empty command, so the backend resolves the configured codex path. A missing binary surfaces naturally via the PTY's 'command not found' output.

## Test plan
- pnpm typecheck → exit 0
- pnpm lint → exit 0, no new warnings
- pnpm db:smoke → 8/8 passed
- pnpm session:smoke → 13/14 passed; the single failure (test 4 list(workspaceId) filters correctly) reproduces on main with the changes stashed and is unrelated to this PR (only one workspace is seeded by default, so wsSecondary === wsPrimary).
- Manual QA scenarios from the spec: create codex session, configure path in Settings, restart and reload, invalid path falls back to PTY error.