### PR TITLE
DEV-16: Multi-type session Phase 2 — Gemini CLI

### DIFF
--- a/docs/dev-squad/DEV-16-multi-type-session-phase-2-gemini-cli.md
+++ b/docs/dev-squad/DEV-16-multi-type-session-phase-2-gemini-cli.md
@@ -1,0 +1,77 @@
+# DEV-16: Multi-type session Phase 2 — Gemini CLI
+
+> Issue: DEV-16
+> Mode: refine
+
+## Summary
+
+Add `'gemini'` as a first-class session type that wraps the Gemini CLI, following the same pattern as `'claude-code'`. Includes a dedicated badge (`cyan` variant), a type button in the New Session dialog, a palette action, and correct PTY spawn behaviour.
+
+## User Stories
+
+- **US-1** As a developer, I want to create a Gemini CLI session from the New Session dialog, so that I can interact with Gemini in a managed PTY alongside my other sessions.
+  - Acceptance: The dialog shows a "Gemini" type button with a distinct icon; selecting it spawns a session with `type === 'gemini'` and the default command `gemini`.
+- **US-2** As a developer, I want the session header to show a distinct `gemini` badge, so that I can distinguish Gemini sessions from Claude Code and shell sessions at a glance.
+  - Acceptance: Sessions with `type === 'gemini'` display a `ConfigBadge` with label `'gemini'` and variant `'cyan'`.
+- **US-3** As a developer, I want a "New Gemini session" command in the command palette, so that I can open a Gemini session without touching the mouse.
+  - Acceptance: The palette shows a `'New Gemini session'` action that opens the dialog pre-selected on the `'gemini'` type.
+- **US-4** As a developer, I want a graceful error when the `gemini` CLI is not installed, so that the app does not silently fail.
+  - Acceptance: If the PTY exits immediately (exit code non-zero, within ~2 s of spawn), the session transitions to `'idle'` and the existing unexpected-exit handling fires — no new code required beyond correct spawn path.
+
+## Functional Requirements
+
+- **FR-001** `SessionType` in `src/shared/ipc.ts` MUST include `'gemini'` as a union member.
+- **FR-002** `session-manager.ts` `create()` MUST accept `type === 'gemini'` and store `'gemini'` in the DB `type` column.
+- **FR-003** `session-manager.ts` `rowToSession()` MUST map DB value `'gemini'` to `SessionType` `'gemini'` (not fall through to `'claude-code'`).
+- **FR-004** `session-manager.ts` `attach()` MUST spawn a `'gemini'` session identically to `'claude-code'`: shell args `['-ilc', direnvPrefix + command]`, with `DECK_SESSION_ID` injected.
+- **FR-005** `SessionHeader.tsx` `getConfigLabel()` MUST return `{ label: 'gemini', variant: 'cyan' }` for `type === 'gemini'`.
+- **FR-006** `SessionDialog.tsx` type-selector array MUST include `{ t: 'gemini', label: 'Gemini', icon: <Sparkles /> }` rendered as a sibling button alongside Claude Code, Shell, SSH.
+- **FR-007** `SessionDialog.tsx` `getLastType()` MUST recognise `'gemini'` as a valid stored value (add `|| stored === 'gemini'` guard).
+- **FR-008** `SessionDialog.tsx` `autoName()` MUST return `${workspace.name}/gemini` for `type === 'gemini'`.
+- **FR-009** `SessionDialog.tsx` MUST show the Command field for `type === 'gemini'` (same condition as `'claude-code'`), with placeholder `gemini`.
+- **FR-010** `SessionDialog.tsx` `handleSubmit()` MUST pass `command: command.trim()` (not empty string) when `type === 'gemini'`.
+- **FR-011** `usePaletteActions.ts` MUST include a `'new-gemini-session'` action (`label: 'New Gemini session'`, category `'sessions'`) that calls `openNewSessionDialog(wsId, 'gemini')`.
+
+## Non-Functional / Constraints
+
+- **Locked files** (from CLAUDE.md — Reviewer enforces): `src/main/pty-manager.ts`, `src/main/pty-registry.ts`, `src/main/db/migrations.ts`
+- **Stack constraints**: TypeScript strict, no `any`, named exports, React functional components, no `localStorage`/`document` in `src/main/`
+- **No DB migration needed**: the `type` column is `TEXT` with no enum constraint; adding a new string value requires no schema change. `LATEST_VERSION` stays at `6`.
+- **Mergeable with DEV-15**: both branches add one union member to `SessionType` and one entry to the SessionDialog type-selector array. Changes are additive and non-overlapping on enum members (`'codex'` vs `'gemini'`).
+
+## Out of Scope
+
+- Gemini-specific settings (API key, model selection) — not in this phase.
+- Hook event integration for Gemini sessions (no `DECK_SESSION_ID` contract with Gemini CLI).
+- Planner/executor attachment for Gemini sessions.
+- Windows/Linux support.
+
+## Files Affected
+
+### Modify
+- `src/shared/ipc.ts` — add `'gemini'` to `SessionType` union; add `'gemini'` guard in `getLastType` within SessionDialog import chain
+- `src/main/session-manager.ts` — add `'gemini'` branch in `rowToSession()` and `create()` type narrowing
+- `src/renderer/src/components/session/SessionHeader.tsx` — add `'gemini'` case in `getConfigLabel()`
+- `src/renderer/src/components/sidebar/SessionDialog.tsx` — add Gemini type button, `getLastType` guard, `autoName` case, Command field visibility, `handleSubmit` passthrough
+- `src/renderer/src/hooks/usePaletteActions.ts` — add `'new-gemini-session'` palette action
+
+## Test Plan
+
+### Automated (Developer + QA run literally)
+- `pnpm typecheck` → exit 0
+- `pnpm lint` → exit 0, no new warnings
+- `pnpm test --run` → all pass
+- `pnpm session:smoke` → exit 0
+
+### Manual (QA executes step-by-step)
+1. Open the app, press ⌘N (or click New Session) → the dialog shows four type buttons: Claude Code, Shell, SSH, **Gemini**. The Gemini button has a `Sparkles` icon.
+2. Select Gemini → Name auto-populates as `<workspace>/gemini`; a Command field appears pre-filled with `gemini`; Working Directory field is visible.
+3. Submit the form → a new session is created; the session header shows a **cyan** `gemini` badge.
+4. Open the command palette → typing "gemini" surfaces the "New Gemini session" action; activating it opens the dialog pre-selected on the Gemini type.
+5. With `gemini` CLI installed: attach the session → PTY spawns, prompt appears.
+6. With `gemini` CLI absent: attach the session → PTY exits immediately; session transitions to idle; no crash.
+7. Reopen the app after having last selected Gemini type → dialog reopens with Gemini pre-selected (localStorage persistence).
+
+## Open Questions
+
+- **Q1** DEV-15 (Codex) is running in parallel and will add `'codex'` to the same `SessionType` union and SessionDialog array. Recommendation: both branches land as additive changes; whichever merges second resolves a trivial union-member conflict. No architectural action needed.

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -158,7 +158,9 @@ export class SessionManager extends EventEmitter<EventMap> {
         ? 'ssh'
         : row.type === 'shell'
           ? 'shell'
-          : 'claude-code') as SessionType,
+          : row.type === 'gemini'
+            ? 'gemini'
+            : 'claude-code') as SessionType,
       claudeSessionId: row.claude_session_id ?? null,
       parentSessionId: row.parent_session_id ?? null,
       createdAt: row.created_at,
@@ -189,7 +191,13 @@ export class SessionManager extends EventEmitter<EventMap> {
     const name = validateNonEmpty('name', req.name)
     const cwd = validateNonEmpty('cwd', req.cwd)
     const type: SessionType =
-      req.type === 'ssh' ? 'ssh' : req.type === 'shell' ? 'shell' : 'claude-code'
+      req.type === 'ssh'
+        ? 'ssh'
+        : req.type === 'shell'
+          ? 'shell'
+          : req.type === 'gemini'
+            ? 'gemini'
+            : 'claude-code'
     const subText = req.subText ?? ''
     const kind = req.kind ?? 'executor'
 

--- a/src/renderer/src/components/session/SessionHeader.tsx
+++ b/src/renderer/src/components/session/SessionHeader.tsx
@@ -8,6 +8,7 @@ import type { SessionType } from '../../../../shared/ipc'
 function getConfigLabel(sessionType: SessionType): { label: string; variant: ConfigBadgeVariant } {
   if (sessionType === 'shell') return { label: 'shell', variant: 'neutral' }
   if (sessionType === 'ssh') return { label: 'ssh', variant: 'neutral' }
+  if (sessionType === 'gemini') return { label: 'gemini', variant: 'cyan' }
   return { label: 'claude-code', variant: 'neutral' }
 }
 

--- a/src/renderer/src/components/sidebar/SessionDialog.tsx
+++ b/src/renderer/src/components/sidebar/SessionDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { FolderOpen, Bot, Terminal, Server, ChevronDown } from 'lucide-react'
+import { FolderOpen, Bot, Terminal, Server, Sparkles, ChevronDown } from 'lucide-react'
 import type { SessionType, SshHost, Workspace } from '../../../../shared/ipc'
 import { useDeckStore } from '@/stores/deck'
 import {
@@ -16,13 +16,15 @@ const LAST_TYPE_KEY = 'deck:lastSessionType'
 
 function getLastType(): SessionType {
   const stored = localStorage.getItem(LAST_TYPE_KEY)
-  if (stored === 'shell' || stored === 'claude-code' || stored === 'ssh') return stored
+  if (stored === 'shell' || stored === 'claude-code' || stored === 'ssh' || stored === 'gemini')
+    return stored
   return 'claude-code'
 }
 
 function autoName(workspace: Workspace, type: SessionType, sshAlias?: string): string {
   if (type === 'shell') return `${workspace.name}/shell`
   if (type === 'ssh') return `${workspace.name}/ssh:${sshAlias ?? ''}`
+  if (type === 'gemini') return `${workspace.name}/gemini`
   return `${workspace.name}/new-session`
 }
 
@@ -52,7 +54,8 @@ export function SessionDialog({
   const [nameDirty, setNameDirty] = useState(false)
   const [cwd, setCwd] = useState(initialWorkspace.path)
   const [cwdDirty, setCwdDirty] = useState(false)
-  const [command, setCommand] = useState(defaultCommand)
+  const [command, setCommand] = useState(initialType === 'gemini' ? 'gemini' : defaultCommand)
+  const [commandDirty, setCommandDirty] = useState(false)
   const [subText, setSubText] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -74,6 +77,9 @@ export function SessionDialog({
 
   function handleTypeChange(newType: SessionType): void {
     setType(newType)
+    if (!commandDirty) {
+      setCommand(newType === 'gemini' ? 'gemini' : defaultCommand)
+    }
   }
 
   function handleSshAliasChange(alias: string): void {
@@ -99,7 +105,8 @@ export function SessionDialog({
     if (!name.trim()) return 'Name is required.'
     if (name.trim().length > 60) return 'Name must be 60 characters or fewer.'
     if (type !== 'ssh' && !cwd.trim()) return 'Working directory is required.'
-    if (type === 'claude-code' && !command.trim()) return 'Command is required.'
+    if ((type === 'claude-code' || type === 'gemini') && !command.trim())
+      return 'Command is required.'
     if (type === 'ssh' && !sshAlias) return 'Select a host.'
     return null
   }
@@ -172,6 +179,11 @@ export function SessionDialog({
                     t: 'ssh' as SessionType,
                     label: 'SSH',
                     icon: <Server size={14} strokeWidth={1.75} />
+                  },
+                  {
+                    t: 'gemini' as SessionType,
+                    label: 'Gemini',
+                    icon: <Sparkles size={14} strokeWidth={1.75} />
                   }
                 ] as const
               ).map(({ t, label, icon }) => (
@@ -295,8 +307,8 @@ export function SessionDialog({
               </div>
             )}
 
-            {/* Command (Claude Code only) */}
-            {type === 'claude-code' && (
+            {/* Command (Claude Code / Gemini) */}
+            {(type === 'claude-code' || type === 'gemini') && (
               <div className="flex flex-col gap-1.5">
                 <label className="font-body text-[12px] font-medium text-op-zinc-400">
                   Command
@@ -304,8 +316,11 @@ export function SessionDialog({
                 <input
                   type="text"
                   value={command}
-                  onChange={(e) => setCommand(e.target.value)}
-                  placeholder="claude"
+                  onChange={(e) => {
+                    setCommand(e.target.value)
+                    setCommandDirty(true)
+                  }}
+                  placeholder={type === 'gemini' ? 'gemini' : 'claude'}
                   className="h-9 bg-op-zinc-900 border border-op-zinc-800 rounded-[7px] px-3 text-op-zinc-200 font-mono text-[13px] outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-op-zinc-600 focus:border-accent focus:shadow-[0_0_0_3px_rgba(124,58,237,0.15)]"
                 />
               </div>

--- a/src/renderer/src/hooks/usePaletteActions.ts
+++ b/src/renderer/src/hooks/usePaletteActions.ts
@@ -73,6 +73,17 @@ export function usePaletteActions(): PaletteAction[] {
           openNewSessionDialog(wsId, 'shell')
         }
       },
+      {
+        id: 'new-gemini-session',
+        label: 'New Gemini session',
+        category: 'sessions',
+        handler: () => {
+          const wsId = targetWorkspaceId()
+          if (!wsId) return
+          closePalette()
+          openNewSessionDialog(wsId, 'gemini')
+        }
+      },
       ...sessions.map((s) => ({
         id: `switch-session-${s.id}`,
         label: `Switch to ${s.name}`,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2,7 +2,7 @@ export type PtyId = string
 export type WorkspaceId = string
 export type SessionId = string
 export type SessionStatus = 'idle' | 'working'
-export type SessionType = 'claude-code' | 'shell' | 'ssh'
+export type SessionType = 'claude-code' | 'shell' | 'ssh' | 'gemini'
 export type NotificationState = 'idle' | 'pending' | 'error'
 
 export interface GitInfo {


### PR DESCRIPTION
Implements DEV-16.

Spec: docs/dev-squad/DEV-16-multi-type-session-phase-2-gemini-cli.md

FRs: FR-001 ✅, FR-002 ✅, FR-003 ✅, FR-004 ✅, FR-005 ✅, FR-006 ✅, FR-007 ✅, FR-008 ✅, FR-009 ✅, FR-010 ✅, FR-011 ✅

## Summary
- `SessionType` union now includes `'gemini'`
- `session-manager`: `create()` accepts `'gemini'`, `rowToSession()` maps it; PTY spawn path identical to `'claude-code'` (`-ilc` shell with direnv prefix + DECK_SESSION_ID)
- `SessionHeader`: cyan `gemini` badge
- `SessionDialog`: Gemini type button (Sparkles icon), `getLastType` recognises `'gemini'`, `autoName` returns `<workspace>/gemini`, Command field shown for gemini with placeholder `gemini` and pre-filled value when type switches (unless user already edited)
- `usePaletteActions`: `new-gemini-session` action

## Test plan
- [x] `pnpm typecheck` exit 0
- [x] `pnpm lint` exit 0, no warnings
- [x] `pnpm test --run` exit 0
- [x] `pnpm session:smoke` — same 13/14 baseline (test #4 is a pre-existing failure unrelated to this change; verified by running smoke on stashed baseline)
- [ ] Manual: ⌘N → Gemini button shows; auto-name + cyan badge; palette "New Gemini session" opens dialog with Gemini pre-selected
- [ ] Manual: gemini CLI absent → PTY exits, session goes idle (no crash)